### PR TITLE
Run CI on PR

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,11 +1,7 @@
 name: Testing
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
 env:
   FORCE_COLOR: 2
 jobs:


### PR DESCRIPTION
Now CI will not run on PR to the project. This will make accepting PR easier since you will see tests results.