### PR TITLE
Switch to conditional benchmark dependencies

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 16
           cache: yarn
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npx handpick --target=devDependencies --target=benchmarkDependencies
       - name: Loading benchmark
         run: node ./test/loading.js
       - name: Size benchmark

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
     "@types/jest": "^27.0.2",
     "clean-publish": "3.0.3",
     "jest": "^27.2.4",
-    "mico-spinner": "^1.3.0",
-    "ora": "^6.0.1",
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"
+  },
+  "benchmarkDependencies": {
+    "mico-spinner": "^1.3.0",
+    "ora": "^6.0.1"
   },
   "clean-publish": {
     "cleanDocs": true


### PR DESCRIPTION
Hey,

I found potential to cleanup your devDependencies by introducing benchmarkDependencies and use on of my tool called handpick.

Let me know what you think.

Fun fact: it uses nanospinner since 4.0.0 :-)