### PR TITLE
Made opts optional in type declaration to match docs and code behavior

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface Options {
 }
 
 interface Spinner {
-  update(opts: Options): Spinner
+  update(opts?: Options): Spinner
   reset(): Spinner
   spin(): Spinner
   stop(opts?: { text?: string; mark?: string }): Spinner


### PR DESCRIPTION
I added an optional flag to opts in the type declaration file to make it so that opts are not required, which matches the docs and the code.