### PR TITLE
Increase default interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function getLines(str = '', width = 80) {
 
 function createSpinner(text = '', opts = {}) {
   let current = 0,
-    interval = opts.interval || 25,
+    interval = opts.interval || 50,
     stream = opts.stream || process.stderr,
     frames = opts.frames || symbols.frames,
     lines = 0,


### PR DESCRIPTION
If you have a heavy task (like in `check-dts`), Node.js will not have resources to call `setInterval` callback every 25 ms. It will lead to frame drops and jerky animation.

Increasing default interval to `50 ms` solves this problem (at least for `check-dts` and `size-limit`).