### PR TITLE
Fix new frames with less or no elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function createSpinner(text = '', opts = {}) {
   let current = 0,
     interval = opts.interval || 50,
     stream = opts.stream || process.stderr,
-    frames = opts.frames || symbols.frames,
+    frames = opts.frames?.length ? opts.frames : symbols.frames,
     color = opts.color || 'yellow',
     lines = 0,
     timer
@@ -63,7 +63,7 @@ function createSpinner(text = '', opts = {}) {
 
     update(opts = {}) {
       text = opts.text || text
-      frames = opts.frames || frames
+      frames = opts.frames?.length ? opts.frames : frames
       interval = opts.interval || interval
       color = opts.color || color
 

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ function createSpinner(text = '', opts = {}) {
       frames = opts.frames || frames
       interval = opts.interval || interval
       color = opts.color || color
+
+      if (frames.length - 1 < current) {
+        current = 0
+      }
+
       return spinner
     },
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function createSpinner(text = '', opts = {}) {
   let current = 0,
     interval = opts.interval || 50,
     stream = opts.stream || process.stderr,
-    frames = opts.frames?.length ? opts.frames : symbols.frames,
+    frames = opts.frames && opts.frames.length ? opts.frames : symbols.frames,
     color = opts.color || 'yellow',
     lines = 0,
     timer
@@ -63,7 +63,7 @@ function createSpinner(text = '', opts = {}) {
 
     update(opts = {}) {
       text = opts.text || text
-      frames = opts.frames?.length ? opts.frames : frames
+      frames = opts.frames && opts.frames.length ? opts.frames : frames
       interval = opts.interval || interval
       color = opts.color || color
 

--- a/test/spin.test.js
+++ b/test/spin.test.js
@@ -36,3 +36,35 @@ it('spins default frames', () => {
   `
   expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)
 })
+
+it('spins defult frames if new ones have no elements', () => {
+  stdout.out = ''
+  let spinner = createSpinner('', { stream: stdout, frames: [] })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+
+  let snapLocal = `"[?25l[1G[33m⠋[39m [?25l[1G[2K[1G[33m⠙[39m [?25l[1G[2K[1G[33m⠹[39m [?25l[1G[2K[1G[33m⠸[39m [?25l[1G[2K[1G[33m⠼[39m [?25l[1G[2K[1G[33m⠴[39m [?25l[1G[2K[1G[33m⠦[39m [?25l[1G[2K[1G[33m⠧[39m [?25l[1G[2K[1G[33m⠇[39m [?25l[1G[2K[1G[33m⠏[39m "`
+  let snapCI = `
+    "[33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    [33m-[39m 
+    "
+  `
+  expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)
+})

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -27,3 +27,51 @@ it('uses custom frames', () => {
   `
   expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)
 })
+
+it('uses custom frames with less elements', () => {
+  stdout.out = ''
+  let spinner = createSpinner('#update', { stream: stdout })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.update({ frames: ['.', 'o'], text: 'Change update' })
+  spinner.spin()
+  spinner.spin()
+
+  let snapLocal = `"[?25l[1G[33m⠋[39m #update[?25l[1G[2K[1G[33m⠙[39m #update[?25l[1G[2K[1G[33m⠹[39m #update[?25l[1G[2K[1G[33m.[39m Change update[?25l[1G[2K[1G[33mo[39m Change update"`
+  let snapCI = `
+    "[33m-[39m #update
+    [33m-[39m #update
+    [33m-[39m #update
+    [33m.[39m Change update
+    [33mo[39m Change update
+    "
+  `
+
+  expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)
+})
+
+it('uses default frames if new ones have no elements', () => {
+  stdout.out = ''
+  let spinner = createSpinner('#update', { stream: stdout })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.update({ frames: [], text: 'Change update' })
+  spinner.spin()
+  spinner.spin()
+
+  let snapLocal = `"[?25l[1G[33m⠋[39m #update[?25l[1G[2K[1G[33m⠙[39m #update[?25l[1G[2K[1G[33m⠹[39m #update[?25l[1G[2K[1G[33m⠸[39m Change update[?25l[1G[2K[1G[33m⠼[39m Change update"`
+  let snapCI = `
+    "[33m-[39m #update
+    [33m-[39m #update
+    [33m-[39m #update
+    [33m-[39m Change update
+    [33m-[39m Change update
+    "
+  `
+
+  expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)
+})


### PR DESCRIPTION
Hi @usmanyunusov,

Found an issue when using new frames that either have no elements (during create/update) or have less elements (during update) than previous one.

**STR**
- No elements: https://stackblitz.com/edit/node-e9sbiw?file=index.js
- Less elements: https://stackblitz.com/edit/node-btwiwm?file=index.js

**Solution**
 - No elements: Will set to default frames. Treating it same as empty string for mark in stop method.
 - Less elements: Will set current to 0. 