### PR TITLE
Extend stop method with color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In order to stop the spinner call `stop`. This will finish drawing the spinning 
 
 ```js
 spinner.stop()
-spinner.stop({ text: 'Done!', mark: ':O' })
+spinner.stop({ text: 'Done!', mark: ':O', color: 'magenta' })
 ```
 
 </details>

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,8 @@ interface Options {
 interface Spinner {
   success(opts?: { text?: string; mark?: string }): Spinner
   error(opts?: { text?: string; mark?: string }): Spinner
-  stop(opts?: { text?: string; mark?: string }): Spinner
-  start(opts?: { text?: string, color?: string }): Spinner
+  stop(opts?: { text?: string; mark?: string; color?: string }): Spinner
+  start(opts?: { text?: string; color?: string }): Spinner
   update(opts?: Options): Spinner
   reset(): Spinner
   clear(): Spinner

--- a/index.js
+++ b/index.js
@@ -82,8 +82,9 @@ function createSpinner(text = '', opts = {}) {
     stop(opts = {}) {
       timer = clearTimeout(timer)
 
-      let mark = pico[color](frames[current])
-      spinner.write(`${opts.mark || mark} ${opts.text || text}\n`, true)
+      let mark = pico[opts.color || color](frames[current])
+      let optsMark = opts.mark && opts.color ? pico[opts.color](opts.mark) : opts.mark
+      spinner.write(`${optsMark || mark} ${opts.text || text}\n`, true)
 
       return isTTY ? spinner.write(`\x1b[?25h`) : spinner
     },

--- a/test/stop.test.js
+++ b/test/stop.test.js
@@ -56,17 +56,17 @@ it('marks spinner as stop with mark', () => {
   spinner.spin()
   spinner.spin()
   spinner.spin()
-  spinner.stop({ mark: 'V' })
+  spinner.stop({ mark: 'V', color: 'magenta' })
 
   let snapLocal = `
-    "[?25l[1G[33m⠋[39m #stop[?25l[1G[2K[1G[33m⠙[39m #stop[?25l[1G[2K[1G[33m⠹[39m #stop[1G[2K[1GV #stop
+    "[?25l[1G[33m⠋[39m #stop[?25l[1G[2K[1G[33m⠙[39m #stop[?25l[1G[2K[1G[33m⠹[39m #stop[1G[2K[1G[35mV[39m #stop
     [?25h"
   `
   let snapCI = `
     "[33m-[39m #stop
     [33m-[39m #stop
     [33m-[39m #stop
-    V #stop
+    [35mV[39m #stop
     "
   `
   expect(stdout.out).toMatchInlineSnapshot(process.env.CI ? snapCI : snapLocal)


### PR DESCRIPTION
Hi @usmanyunusov ,

As "stop" already allows custom mark to be used. I think it would be useful to allow mark's color change as well. For instance If I want to have "!" (warning) mark in different color when I stop the spinner.

**Solution**
Allow "color" property to be used for changing custom's or spinner's mark.
No color will be added to custom mark if not passed in options, respecting current behavior. But if you think that custom mark should always use some color, feel free to change logic and tests.

**Workarounds**
❌ Although you can achieve desired behavior with current API like this:
```
spinner.update({ text: 'This is a warning', color: 'magenta', frames: Array(10).fill('!') });
spinner.stop();
spinner.update({ color: 'yellow', frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] }); // To revert back spinner color
``` 

❌ Or like this, if [PR17](https://github.com/usmanyunusov/nanospinner/pull/17) goes through:
```
spinner.update({ text: 'This is a warning', color: 'magenta', frames: ['!'] });
spinner.stop();
spinner.update({ color: 'yellow', frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] }); // To revert back spinner color
```

✔️ I find this more user friendly:
```
spinner.stop({ text: 'This is a warning', mark: '!', color: 'magenta' });
```