### PR TITLE
add update option to success/error/warn/stop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,10 +7,10 @@ interface Options {
 }
 
 interface Spinner {
-  success(opts?: { text?: string; mark?: string }): Spinner
-  error(opts?: { text?: string; mark?: string }): Spinner
-  warn(opts?: { text?: string; mark?: string }): Spinner
-  stop(opts?: { text?: string; mark?: string; color?: string }): Spinner
+  success(opts?: { text?: string; mark?: string; update?: boolean }): Spinner
+  error(opts?: { text?: string; mark?: string; update?: boolean }): Spinner
+  warn(opts?: { text?: string; mark?: string; update?: boolean }): Spinner
+  stop(opts?: { text?: string; mark?: string; update?: boolean; color?: string }): Spinner
   start(opts?: { text?: string; color?: string }): Spinner
   update(opts?: Options): Spinner
   reset(): Spinner

--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ function createSpinner(text = '', opts = {}) {
 
       let mark = pico[opts.color || color](frames[current])
       let optsMark = opts.mark && opts.color ? pico[opts.color](opts.mark) : opts.mark
-      spinner.write(`${optsMark || mark} ${opts.text || text}\n`, true)
+      let update = opts.update ?? false
+      spinner.write(`${optsMark || mark} ${opts.text || text}${update ? '' : '\n'}`, true)
 
       return isTTY ? spinner.write(`\x1b[?25h`) : spinner
     },


### PR DESCRIPTION
This enables updating the same spinner multiple times without creating a new line, e.g. for use in a watch command.