### PR TITLE
feature: add `info()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ spinner.error()
 spinner.error({ text: 'Error!', mark: ':(' })
 ```
 
+__`.info(options?)`__
+
+Use `info` call to stop the spinning animation and replace the spinning symbol with info mark character to indicate info completion.
+
+```js
+spinner.info()
+spinner.info({ text: 'Info!', mark: 'i' })
+```
+
 __`.update(options?)`__
 
 Use `update` call to dynamically change

--- a/consts.js
+++ b/consts.js
@@ -18,6 +18,7 @@ const symbols = {
   tick: supportUnicode ? '✔' : '√',
   cross: supportUnicode ? '✖' : '×',
   warn: supportUnicode ? '⚠' : '!!',
+  info: supportUnicode ? 'ℹ' : 'i',
 }
 
 module.exports = { isTTY, symbols }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ interface Spinner {
   success(opts?: { text?: string; mark?: string }): Spinner
   error(opts?: { text?: string; mark?: string }): Spinner
   warn(opts?: { text?: string; mark?: string }): Spinner
+  info(opts?: { text?: string; mark?: string }): Spinner
   stop(opts?: { text?: string; mark?: string; color?: string }): Spinner
   start(opts?: { text?: string; color?: string }): Spinner
   update(opts?: Options): Spinner

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const pico = require('picocolors')
 
 const { isTTY, symbols } = require('./consts')
 
-const { green, red, yellow } = pico
+const { green, red, yellow, blue } = pico
 
 function getLines(str = '', width = 80) {
   return str
@@ -110,6 +110,11 @@ function createSpinner(text = '', opts = {}) {
 
     warn(opts = {}) {
       let mark = yellow(symbols.warn)
+      return spinner.stop({ mark, ...opts })
+    },
+
+    info(opts = {}) {
+      let mark = blue(symbols.info)
       return spinner.stop({ mark, ...opts })
     },
 

--- a/test/info.test.js
+++ b/test/info.test.js
@@ -1,0 +1,72 @@
+let { test } = require('uvu')
+let { is } = require('uvu/assert')
+
+let { createSpinner } = require('../index.js')
+
+let stdout = { out: '' }
+stdout.write = (symbols) => {
+  stdout.out += symbols
+}
+
+test.before.each(() => {
+  stdout.out = ''
+})
+
+test('marks spinner as info', () => {
+  let spinner = createSpinner('#info', { stream: stdout })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.info()
+
+  let snapLocal =
+    '\x1B[?25l\x1B[1G\x1B[33m⠋\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠙\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠹\x1B[39m #info\x1B[1G\x1B[2K\x1B[1G\x1B[34mℹ\x1B[39m #info\n' +
+    '\x1B[?25h'
+  let snapCI =
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[34mℹ\x1B[39m #info\n'
+
+  is(stdout.out, process.env.CI ? snapCI : snapLocal)
+})
+
+test('marks spinner as info with message', () => {
+  let spinner = createSpinner('#info', { stream: stdout })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.info({ text: 'Information' })
+
+  let snapLocal =
+    '\x1B[?25l\x1B[1G\x1B[33m⠋\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠙\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠹\x1B[39m #info\x1B[1G\x1B[2K\x1B[1G\x1B[34mℹ\x1B[39m Information\n' +
+    '\x1B[?25h'
+  let snapCI =
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[33m-\x1B[39m #info\n' +
+    '\x1B[34mℹ\x1B[39m Information\n'
+
+  is(stdout.out, process.env.CI ? snapCI : snapLocal)
+})
+
+test('marks spinner as info with mark', () => {
+  let spinner = createSpinner('#info', { stream: stdout })
+
+  spinner.spin()
+  spinner.spin()
+  spinner.spin()
+  spinner.info({ mark: 'ii' })
+
+  let snapLocal =
+    '\x1B[?25l\x1B[1G\x1B[33m⠋\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠙\x1B[39m #info\x1B[?25l\x1B[1G\x1B[2K\x1B[1G\x1B[33m⠹\x1B[39m #info\x1B[1G\x1B[2K\x1B[1Gii #info\n' +
+    '\x1B[?25h'
+  let snapCI =
+    '\x1B[33m-\x1B[39m #info\n\x1B[33m-\x1B[39m #info\n\x1B[33m-\x1B[39m #info\nii #info\n'
+
+  is(stdout.out, process.env.CI ? snapCI : snapLocal)
+})
+
+test.run()


### PR DESCRIPTION
This PR adds a method to replicate the `info()` method from `ora`. I believe this will help people migrate to this package a bit more seamlessly.