### PR TITLE
chore: update benchmarks and package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ setTimeout(() => {
 ```
 
 - Only **single dependency** (picocolors).
-- It **45 times** smaller than `ora`.
+- It is **16 times** smaller than `ora`.
 - Support both CJS and ESM projects.
 - **TypeScript** type declarations included.
 
@@ -28,7 +28,7 @@ The space in `node_modules` including sub-dependencies:
 ```diff
 $ node ./test/size.js
 Data from packagephobia.com
-  ora           597 kB
+  ora           210 kB
 + nanospinner    13 kB
 ```
 


### PR DESCRIPTION
`ora` slimmed down to 210kB in the v8 update, so the README is a bit out-of-date.

I could also see a comparison to v5.4.1 (585kB) being useful as it is the most used version at 17 million downloads per week. Let me know if that is something you would be interested in and I could add it in this PR. 