### PR TITLE
chore: export `Spinner`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ interface Options {
   color?: Color
 }
 
-interface Spinner {
+export interface Spinner {
   success(opts?: { text?: string; mark?: string; update?: boolean } | string): Spinner
   error(opts?: { text?: string; mark?: string; update?: boolean } | string): Spinner
   warn(opts?: { text?: string; mark?: string; update?: boolean } | string): Spinner


### PR DESCRIPTION
In `nanospinner@1.1.0`, `Spinner` interface was implicitly exported. But in `nanospinner@1.2.0`, `Spinner` interface is no longer being exported. This breaks existing usages, with error message such as:

```
Commons/utils/spinningLogger.ts:2:25 - error TS2459: Module '"nanospinner"' declares 'Spinner' locally, but it is not exported.

2 import { createSpinner, Spinner } from "nanospinner";
                          ~~~~~~~

  node_modules/nanospinner/dist/index.d.ts:10:11
    10 interface Spinner {
                 ~~~~~~~
    'Spinner' is declared here.
```

This CR fixes that by explicitly exporting Spinner.