### PR TITLE
refactor: use util.styleText instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "format": "prettier --write src",
     "publish": "clean-publish"
   },
-  "dependencies": {
-    "picocolors": "^1.1.1"
-  },
   "devDependencies": {
     "@types/node": "^22.8.4",
     "c8": "^10.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
     devDependencies:
       '@types/node':
         specifier: ^22.8.4
@@ -289,9 +285,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -652,8 +645,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-
-  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,10 @@
 import tty from 'node:tty'
 import process from 'node:process'
+import { inspect } from 'node:util'
+
+const colorNames = Object.entries(inspect.colors)
+  .filter((i: any[]) => i[1][1] == 39)
+  .map((i: any[]) => i[0])
 
 /**
  * This file contains code adapted from the following projects:
@@ -39,4 +44,4 @@ const symbols = {
   info: supportUnicode ? 'ℹ' : 'i',
 }
 
-export { isTTY, symbols }
+export { isTTY, symbols, colorNames }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,26 @@
-import type { Colors } from 'picocolors/types'
-import pc from 'picocolors'
-import { isTTY, symbols } from './consts'
+import { styleText } from 'node:util'
+import { isTTY, symbols, colorNames } from './consts'
 
-type Color = keyof Omit<Colors, 'isColorSupported'>
+// From https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+type Color =
+  | 'black'
+  | 'blackBright'
+  | 'blue'
+  | 'blueBright'
+  | 'cyan'
+  | 'cyanBright'
+  | 'gray'
+  | 'green'
+  | 'greenBright'
+  | 'grey'
+  | 'magenta'
+  | 'magentaBright'
+  | 'red'
+  | 'redBright'
+  | 'white'
+  | 'whiteBright'
+  | 'yellow'
+  | 'yellowBright'
 
 interface Options {
   stream?: NodeJS.WriteStream
@@ -90,7 +108,7 @@ export function createSpinner(text = '', opts: Options = {}) {
     },
 
     render() {
-      let str = `${pc[color](frames[current])} ${text}`
+      let str = `${addColor(color, frames[current])} ${text}`
       isTTY ? spinner.write(`\x1b[?25l`) : (str += '\n')
       spinner.write(str, true)
       isTTY && (lines = getLines(str, stream.columns))
@@ -136,7 +154,7 @@ export function createSpinner(text = '', opts: Options = {}) {
       cleanupProcessEvents()
 
       const update = getUpdate(opts)
-      const mark = pc[getColor(opts)](getMark(opts, frames[current]))
+      const mark = addColor(getColor(opts), getMark(opts, frames[current]))
       const text = getText(opts)
 
       spinner.write(opts ? `${mark} ${text}${update ? '' : '\n'}` : '', true)
@@ -191,6 +209,11 @@ export function createSpinner(text = '', opts: Options = {}) {
     }
 
     process.exit(signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1)
+  }
+
+  function addColor(name: Color, text: string) {
+    if (!colorNames.includes(name)) return text
+    return styleText([name], text)
   }
 
   return spinner


### PR DESCRIPTION
In this PR, i remove `picocolors` and use Node.js builtin `util.styleText`. **NOTE**, `util.styleText` is available since Node.js `v20.12.0` and above. If you don't want to target them, you can close this PR.
